### PR TITLE
Merging changelog to development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 12.10.0 2023-04-25
+### Added
+* `list_institutes` and `list_institutes_2` management commands for displaying institute opt in/out information.
+
+### Changed
+* `list_users` management command to display more user role information.
+
 ## 12.9.9 2022-03-07
 ### Fixed
 * After two years of solid development, 1300 commits, 33 million API requests and over 2.5 million sequences, it's probably about time to give this thing a version number and CHANGELOG.


### PR DESCRIPTION
- All changes (including to changelog) should really be made from `development` -> `stable`.
- So, the changelog is being merged to `development`, and future changelog updates will be made in `development` and then pushed to `stable`.