### PR TITLE
Tests, updates and fixes for the anonymous_sample_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 12.12.0 2023-05-30
+### Added
+* Tests for `add biosample` and `addempty biosample` behaviour when `anonymous_sample_id` is provided as `""`, or `None`.
+* Tests for `add library` when biosamples are force created.
+
+### Changed
+* `addempty biosample` no longer automatically generates an `anonymous_sample_id` if one is not provided by a user.
+
+### Fixed
+* `add biosample` no longer allows reset of `anonymous_sample_id` by providing an empty string in `partial` mode.
+
 ## 12.11.0 2023-05-25
 ### Added 
 * The `anonymous_sample_id` field, on the `BiosampleArtifact` model.

--- a/majora2/test/test_biosampleartifact.py
+++ b/majora2/test/test_biosampleartifact.py
@@ -20,17 +20,21 @@ import requests
 default_central_sample_id = "HOOT-00001"
 default_central_sample_id_2 = "HOOT-00002"
 
-response = requests.post(
-                "http://%s:%s/issue" % (settings.ZANA_HOST, settings.ZANA_PORT),
-                json={
-                    "org_code" : settings.ZANA_POOL_ANON,
-                    "prefix" : settings.ZANA_POOL_ANON,
-                    "pool" : settings.ZANA_POOL_ANON,
-                    "linkage_id" : default_central_sample_id,
-                }
-            )
-assert response.ok
-default_anonymous_sample_id = response.json()["zeal"]
+if settings.ISSUE_ZANA_IDS:
+    response = requests.post(
+                    "http://%s:%s/issue" % (settings.ZANA_HOST, settings.ZANA_PORT),
+                    json={
+                        "org_code" : settings.ZANA_POOL_ANON,
+                        "prefix" : settings.ZANA_POOL_ANON,
+                        "pool" : settings.ZANA_POOL_ANON,
+                        "linkage_id" : default_central_sample_id,
+                    }
+                )
+    assert response.ok
+    default_anonymous_sample_id = response.json()["zeal"]
+else:
+    default_anonymous_sample_id = None
+
 user_anonymous_sample_id = "%s-%s" % (settings.ANON_PREFIXES[0] if settings.ANON_PREFIXES else "TEST", "00000001")
 user_anonymous_sample_id_2 = "%s-%s" % (settings.ANON_PREFIXES[0] if settings.ANON_PREFIXES else "TEST", "00000002")                     
 
@@ -1104,6 +1108,54 @@ class OAuthBiosampleArtifactTest(OAuthAPIClientBase):
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
         assert bs.anonymous_sample_id == user_anonymous_sample_id
+    
+    def test_add_change_biosample_anonymous_sample_id_null_preserved_ok(self):
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
+
+        # Add, with id
+        payload = copy.deepcopy(self.default_payload)
+        payload["biosamples"][0]["anonymous_sample_id"] = user_anonymous_sample_id
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+        # Add, with id key but its empty
+        payload = copy.deepcopy(self.default_payload)
+        payload["biosamples"][0]["anonymous_sample_id"] = ""
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id  
+
+        # Partial update, with id key but its empty
+        update_payload = {
+            "username": "user",
+            "token": "oauth",
+            "biosamples": [
+                {
+                    "central_sample_id": default_central_sample_id,
+                    "anonymous_sample_id" : "",
+                }
+
+            ],
+            "client_name": "pytest",
+            "client_version": 1,
+        }
+        response = self.c.post(self.update_endpoint, update_payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.update_token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
 
     def test_add_biosample_anonymous_sample_id_duplicate_bad(self):
         perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
@@ -1859,7 +1911,8 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
             assert sample.get_metadata_as_struct() == biosample.get("metadata", {})
             assert len(sample.get_metadata_as_struct()) == len(biosample.get("metadata", {}))
     
-    def test_put_empty_biosampleartifact_anonymous_sample_id_default_ok(self):
+    def test_put_empty_biosampleartifact_put_again_anonymous_sample_id_ok(self):
+        # Put, no id
         payload = {
             "username": self.user.username,
             "token": "oauth",
@@ -1873,12 +1926,12 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         self.assertEqual(j["errors"], 0)
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
-        assert bs.anonymous_sample_id == default_anonymous_sample_id
+        assert bs.anonymous_sample_id == None
 
-    def test_put_empty_biosampleartifact_anonymous_sample_id_ok(self):
         perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
         self.user.user_permissions.add(perm)
 
+        # Re-put, with id
         payload = {
             "username": self.user.username,
             "token": "oauth",
@@ -1894,7 +1947,8 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
         assert bs.anonymous_sample_id == user_anonymous_sample_id
 
-    def test_change_empty_biosampleartifact_anonymous_sample_id_ok(self):
+    def test_put_empty_biosampleartifact_sid_anonymous_sample_id_ok(self):
+        # Put, no ids
         payload = {
             "username": self.user.username,
             "token": "oauth",
@@ -1908,18 +1962,132 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         self.assertEqual(j["errors"], 0)
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
-        assert bs.anonymous_sample_id == default_anonymous_sample_id
+        assert bs.sender_sample_id == None
+        assert bs.anonymous_sample_id == None
+
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
+
+        # Put, ids
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {"central_sample_id": default_central_sample_id, "sender_sample_id" : "SECRET-0001", "anonymous_sample_id" : user_anonymous_sample_id},
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.sender_sample_id == "SECRET-0001"
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+        # Re-put, no ids
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {"central_sample_id": default_central_sample_id},
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.sender_sample_id == "SECRET-0001"
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+    def test_change_empty_biosampleartifact_anonymous_sample_id_ok(self):
+        # Put, no id
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {"central_sample_id": default_central_sample_id},
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == None
+
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
+
+        # Put, with id
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {"central_sample_id": default_central_sample_id, "anonymous_sample_id" : user_anonymous_sample_id},
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
 
         perm = Permission.objects.get(codename="can_change_anonymous_sample_id")
         self.user.user_permissions.add(perm)
 
+        # Put, changing id
         payload = {
             "username": self.user.username,
             "token": "oauth",
             "biosamples": [
                 {
                     "central_sample_id": default_central_sample_id, 
-                    "anonymous_sample_id" : user_anonymous_sample_id,
+                    "anonymous_sample_id" : user_anonymous_sample_id_2,
+                },
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id_2
+
+    def test_change_empty_biosampleartifact_anonymous_sample_id_null_preserved_ok(self):
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
+
+        # Put, with id
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {"central_sample_id": default_central_sample_id, "anonymous_sample_id" : user_anonymous_sample_id},
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+        # Put, with id key but its empty
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {
+                    "central_sample_id": default_central_sample_id, 
+                    "anonymous_sample_id" : "",
                 },
             ],
         }
@@ -2057,29 +2225,16 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         assert models.BiosampleArtifact.objects.count() == 0
 
     def test_change_empty_biosampleartifact_anonymous_sample_id_noperm_bad(self):
-        payload = {
-            "username": self.user.username,
-            "token": "oauth",
-            "biosamples": [
-                {"central_sample_id": default_central_sample_id},
-            ],
-        }
-        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
-        self.assertEqual(200, response.status_code)
-        j = response.json()
-        self.assertEqual(j["errors"], 0)
-        assert models.BiosampleArtifact.objects.count() == 1
-        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
-        assert bs.anonymous_sample_id == default_anonymous_sample_id
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
 
-        # ID is the same, no effect
         payload = {
             "username": self.user.username,
             "token": "oauth",
             "biosamples": [
-                {  
-                    "central_sample_id": default_central_sample_id,
-                    "anonymous_sample_id" : default_anonymous_sample_id,
+                {
+                    "central_sample_id": default_central_sample_id, 
+                    "anonymous_sample_id" : user_anonymous_sample_id,
                 },
             ],
         }
@@ -2089,9 +2244,9 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         self.assertEqual(j["errors"], 0)
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
-        assert bs.anonymous_sample_id == default_anonymous_sample_id
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
 
-        # ID is different, rejected
+        # ID is the same, no effect
         payload = {
             "username": self.user.username,
             "token": "oauth",
@@ -2105,11 +2260,30 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
         self.assertEqual(200, response.status_code)
         j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+        # ID is different, rejected
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {  
+                    "central_sample_id": default_central_sample_id,
+                    "anonymous_sample_id" : user_anonymous_sample_id_2,
+                },
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
         self.assertEqual(j["errors"], 1)
         self.assertEqual("You do not have permission to change the anonymous_sample_id on BiosampleArtifact %s" % default_central_sample_id, "".join(j["messages"][0]))
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
-        assert bs.anonymous_sample_id == default_anonymous_sample_id       
+        assert bs.anonymous_sample_id == user_anonymous_sample_id       
 
     def test_put_empty_biosampleartifact_anonymous_sample_id_wrongformat_bad(self):
         perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
@@ -2233,6 +2407,19 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
         assert bs.anonymous_sample_id == user_anonymous_sample_id
 
+        # Add full record with empty id
+        payload = copy.deepcopy(default_payload)
+        payload["username"] = "oauth"
+        payload["token"] = "oauth"
+        payload["biosamples"][0]["anonymous_sample_id"] = ""
+        response = self.c.post(self.endpoint.replace("addempty", "add"), payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.full_token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
     def test_add_then_put_empty_biosampleartifact_anonymous_sample_preserved_ok(self):
         perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
         self.user.user_permissions.add(perm)
@@ -2267,3 +2454,53 @@ class OAuthEmptyBiosampleArtifactTest(OAuthAPIClientBase):
         assert models.BiosampleArtifact.objects.count() == 1
         bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
         assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+        # Add empty record with empty key
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {
+                    "central_sample_id": default_central_sample_id, 
+                    "anonymous_sample_id" : "",
+                },
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+
+    def test_put_empty_biosampleartifact_then_add_default_anonymous_sample_ok(self):
+        # Add empty record without id
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {
+                    "central_sample_id": default_central_sample_id, 
+                },
+            ],
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == None
+
+        # Add full record without id, one should be generated
+        payload = copy.deepcopy(default_payload)
+        payload["username"] = "oauth"
+        payload["token"] = "oauth"
+        response = self.c.post(self.endpoint.replace("addempty", "add"), payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.full_token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 1
+        bs = models.BiosampleArtifact.objects.get(central_sample_id=default_central_sample_id)
+        assert bs.anonymous_sample_id == default_anonymous_sample_id

--- a/majora2/test/test_libraryartifact.py
+++ b/majora2/test/test_libraryartifact.py
@@ -1,8 +1,13 @@
 from django.urls import reverse
+from django.contrib.auth.models import User, Permission
+from django.conf import settings
 
 from majora2 import models
 from tatl import models as tmodels
 from majora2.test.test_basic_api import OAuthAPIClientBase
+
+user_anonymous_sample_id = "%s-%s" % (settings.ANON_PREFIXES[0] if settings.ANON_PREFIXES else "TEST", "00000001")
+user_anonymous_sample_id_2 = "%s-%s" % (settings.ANON_PREFIXES[0] if settings.ANON_PREFIXES else "TEST", "00000002")                     
 
 class OAuthLibraryArtifactTest(OAuthAPIClientBase):
     def setUp(self):
@@ -11,6 +16,10 @@ class OAuthLibraryArtifactTest(OAuthAPIClientBase):
         self.endpoint = reverse("api.artifact.library.add")
         self.scope = "majora2.add_biosampleartifact majora2.add_libraryartifact majora2.add_librarypoolingprocess majora2.change_biosampleartifact majora2.change_libraryartifact majora2.change_librarypoolingprocess"
         self.token = self._get_token(self.scope)
+
+        self.empty_bio_endpoint = reverse("api.artifact.biosample.addempty")
+        self.empty_bio_scope = "majora2.force_add_biosampleartifact majora2.add_biosampleartifact majora2.change_biosampleartifact majora2.add_biosourcesamplingprocess majora2.change_biosourcesamplingprocess"
+        self.empty_bio_token = self._get_token(self.empty_bio_scope)
 
     def test_add_basic_library_ok(self):
         lib_count = models.LibraryArtifact.objects.count()
@@ -200,3 +209,120 @@ class OAuthLibraryArtifactTest(OAuthAPIClientBase):
         self.assertEqual(j["errors"], 1)
         self.assertIn("Failed to get or create a LibraryArtifact. Possible race condition detected", "".join(j["messages"]))
         self.assertIn("Likely caught other process in the middle of adding a LibraryArtifact, advised to resubmit", "".join(j["messages"]))
+
+    def test_add_library_force_biosamples(self):
+        library_name = "HOOT-LIB-1"
+        payload = {
+            "biosamples": [
+                {
+                    "central_sample_id": "HOOT-00001",
+                    "library_source": "VIRAL_RNA",
+                    "library_selection": "PCR",
+                    "library_strategy": "AMPLICON",
+                },
+                {
+                    "central_sample_id": "HOOT-00002",
+                    "library_source": "VIRAL_RNA",
+                    "library_selection": "PCR",
+                    "library_strategy": "AMPLICON",
+                }
+            ],
+            "library_layout_config": "SINGLE",
+            "library_name": library_name,
+            "library_seq_kit": "KIT",
+            "library_seq_protocol": "PROTOCOL",
+            "username": "OAUTH",
+            "token": "OAUTH",
+            "force_biosamples" : True,
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.LibraryArtifact.objects.count() == 1
+        library = models.LibraryArtifact.objects.get(dice_name=library_name)
+        assert library.layout_config == payload.get("library_layout_config")
+        assert library.layout_read_length == payload.get("library_layout_read_length")
+        assert library.layout_insert_length == payload.get("library_layout_insert_length")
+        assert library.seq_kit == payload.get("library_seq_kit")
+        assert library.seq_protocol == payload.get("library_seq_protocol")
+
+        assert models.BiosampleArtifact.objects.count() == 2
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00001")
+        assert bs.anonymous_sample_id == None
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00002")
+        assert bs.anonymous_sample_id == None
+    
+    def test_add_library_force_biosample_addempty_anonymous_sample_id(self):
+        library_name = "HOOT-LIB-1"
+        payload = {
+            "biosamples": [
+                {
+                    "central_sample_id": "HOOT-00001",
+                    "library_source": "VIRAL_RNA",
+                    "library_selection": "PCR",
+                    "library_strategy": "AMPLICON",
+                },
+                {
+                    "central_sample_id": "HOOT-00002",
+                    "library_source": "VIRAL_RNA",
+                    "library_selection": "PCR",
+                    "library_strategy": "AMPLICON",
+                }
+            ],
+            "library_layout_config": "SINGLE",
+            "library_name": library_name,
+            "library_seq_kit": "KIT",
+            "library_seq_protocol": "PROTOCOL",
+            "username": "OAUTH",
+            "token": "OAUTH",
+            "force_biosamples" : True,
+        }
+        response = self.c.post(self.endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.LibraryArtifact.objects.count() == 1
+        library = models.LibraryArtifact.objects.get(dice_name=library_name)
+        assert library.layout_config == payload.get("library_layout_config")
+        assert library.layout_read_length == payload.get("library_layout_read_length")
+        assert library.layout_insert_length == payload.get("library_layout_insert_length")
+        assert library.seq_kit == payload.get("library_seq_kit")
+        assert library.seq_protocol == payload.get("library_seq_protocol")
+
+        assert models.BiosampleArtifact.objects.count() == 2
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00001")
+        assert bs.anonymous_sample_id == None
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00002")
+        assert bs.anonymous_sample_id == None
+
+        perm = Permission.objects.get(codename="can_add_anonymous_sample_id")
+        self.user.user_permissions.add(perm)
+
+        # Add empty records with id
+        payload = {
+            "username": self.user.username,
+            "token": "oauth",
+            "biosamples": [
+                {
+                    "central_sample_id": "HOOT-00001", 
+                    "anonymous_sample_id" : user_anonymous_sample_id,
+                    "sender_sample_id" : "SECRET-00001",
+                },
+                {
+                    "central_sample_id": "HOOT-00002", 
+                    "anonymous_sample_id" : user_anonymous_sample_id_2,
+                },
+            ],
+        }
+        response = self.c.post(self.empty_bio_endpoint, payload, secure=True, content_type="application/json", HTTP_AUTHORIZATION="Bearer %s" % self.empty_bio_token)
+        self.assertEqual(200, response.status_code)
+        j = response.json()
+        self.assertEqual(j["errors"], 0)
+        assert models.BiosampleArtifact.objects.count() == 2
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00001")
+        assert bs.anonymous_sample_id == user_anonymous_sample_id
+        assert bs.sender_sample_id == "SECRET-00001"
+        bs = models.BiosampleArtifact.objects.get(central_sample_id="HOOT-00002")
+        assert bs.anonymous_sample_id == user_anonymous_sample_id_2
+        assert bs.sender_sample_id == None


### PR DESCRIPTION
* Tests for `add biosample` and `addempty biosample` behaviour when `anonymous_sample_id` is provided as `""`, or `None`.
* Tests for `add library` when biosamples are force created.
* `addempty biosample` no longer automatically generates an `anonymous_sample_id` if one is not provided by a user.
* `add biosample` no longer allows reset of `anonymous_sample_id` by providing an empty string in `partial` mode.