### PR TITLE
Support for anonymous_sample_id in task outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 12.12.1 2023-06-02
+### Changed
+* The tasks `task_get_sequencing_faster` and `task_get_pag_v2` now include the `anonymous_sample_id` in the output `BiosampleArtifact` fields.
+
 ## 12.12.0 2023-05-30
 ### Added
 * Tests for `add biosample` and `addempty biosample` behaviour when `anonymous_sample_id` is provided as `""`, or `None`.

--- a/majora2/tasks.py
+++ b/majora2/tasks.py
@@ -60,6 +60,7 @@ def task_get_sequencing_faster(request, api_o, json_data, user=None, **kwargs):
                 biosample_ids = models.MajoraArtifactProcessRecord.objects.filter(out_artifact__id=lib_id).values_list("in_artifact__id", flat=True).distinct()
                 lib["biosamples"] = {x["central_sample_id"]: x for x in models.BiosampleArtifact.objects.filter(id__in=biosample_ids).values(
                     'central_sample_id',
+                    'anonymous_sample_id',
                     'root_sample_id',
                     'sample_type_collected',
                     'root_biosample_source_id',
@@ -351,6 +352,7 @@ def task_get_pag_v2(request, api_o, json_data, user=None, **kwargs):
     ).values(
             'groups__publishedartifactgroup__published_name',
             'central_sample_id',
+            'anonymous_sample_id',
             collection_date=F('created__biosourcesamplingprocess__collection_date'),
             received_date=F('created__biosourcesamplingprocess__received_date'),
             submission_user=F('created__biosourcesamplingprocess__submission_user__username'),


### PR DESCRIPTION
* The tasks `task_get_sequencing_faster` and `task_get_pag_v2` now include the `anonymous_sample_id` in the output `BiosampleArtifact` fields.

