### PR TITLE
Added `--reassign` argument for `remove_user_groups` management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 12.13.1 2026-02-06
+### Changed
+* Management command `remove_user_groups` now allows reassigning of select permissions from this group directly.
+
 ## 12.13.0 2026-02-04
 ### Added
 * Added legacy management commands `cog_load_accessions` and `reset_user`.

--- a/tatl/management/commands/remove_user_groups.py
+++ b/tatl/management/commands/remove_user_groups.py
@@ -14,6 +14,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--exclude", nargs="*", default=[], help="Usernames to exclude"
         )
+        parser.add_argument(
+            "--reassign",
+            nargs="*",
+            default=[],
+            help="Reassign permissions to these users directly",
+        )
 
     def handle(self, *args, **options):
         try:
@@ -30,6 +36,9 @@ class Command(BaseCommand):
 
         exclude_users = set(options["exclude"])
         removed_users = []
+        reassigned_permissions = group.permissions.filter(
+            codename__in=options["reassign"]
+        )
 
         for user in User.objects.filter(groups=group):
             if user.username in exclude_users:
@@ -41,6 +50,13 @@ class Command(BaseCommand):
             sys.stderr.write(
                 "[NOTE] User %s removed from group %s\n" % (user.username, group.name)
             )
+
+            for permission in reassigned_permissions:
+                user.user_permissions.add(permission)
+                sys.stderr.write(
+                    "[NOTE] Permission %s reassigned to user %s\n"
+                    % (permission.codename, user.username)
+                )
 
         if removed_users:
             treq = models.TatlPermFlex(

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
-__VERSION__ = "12.13.0-climbcovid"
+__VERSION__ = "12.13.1-climbcovid"
 __VERSION_NAME__ = "Don't Panic"


### PR DESCRIPTION
- Added `--reassign` argument to `remove_user_groups` management command, which enables re-assigning direct permission on select perms from the group the users are being removed from.